### PR TITLE
Support all versions specified in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ php:
   - 7.0
   - 7.1
 
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+      env: COMPOSER_FLAGS="--prefer-lowest"
+
 sudo: false
 
 cache:
@@ -13,6 +19,6 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-  - composer update --prefer-dist --no-interaction
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script: make test

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "twig/twig": ">=1.8,<2.0"
+        "twig/twig": ">=1.15,<2.0"
     },
     "require-dev": {
         "dnode/dnode": "~0.2",

--- a/src/TwigJs/Compiler/ForCompiler.php
+++ b/src/TwigJs/Compiler/ForCompiler.php
@@ -73,7 +73,7 @@ class ForCompiler implements TypeCompilerInterface
             ->raw(";\n")
         ;
 
-        if ($node->hasNode('else')) {
+        if ($this->hasElseNode($node)) {
             $compiler->write("var $iteratedName = false;\n");
         }
 
@@ -117,7 +117,7 @@ class ForCompiler implements TypeCompilerInterface
         $ref = new \ReflectionProperty($node, 'loop');
         $ref->setAccessible(true);
         $loop = $ref->getValue($node);
-        $loop->setAttribute('else', $node->hasNode('else'));
+        $loop->setAttribute('else', $this->hasElseNode($node));
         $loop->setAttribute('with_loop', $node->getAttribute('with_loop'));
         $loop->setAttribute('ifexpr', $node->getAttribute('ifexpr'));
 

--- a/src/TwigJs/Compiler/ForCompiler.php
+++ b/src/TwigJs/Compiler/ForCompiler.php
@@ -135,7 +135,7 @@ class ForCompiler implements TypeCompilerInterface
             ->write("}, this);\n")
         ;
 
-        if ($node->hasNode('else')) {
+        if ($this->hasElseNode($node)) {
             $compiler
                 ->write("if (!$iteratedName) {\n")
                 ->indent()
@@ -149,5 +149,18 @@ class ForCompiler implements TypeCompilerInterface
             $compiler->leaveScope();
         }
         $this->count = $count;
+    }
+
+    private function hasElseNode(\Twig_NodeInterface $node)
+    {
+        if (!$node->hasNode('else')) {
+            return false;
+        }
+
+        if (null === $node->getNode('else')) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/TwigJs/Compiler/IncludeCompiler.php
+++ b/src/TwigJs/Compiler/IncludeCompiler.php
@@ -41,14 +41,6 @@ class IncludeCompiler implements TypeCompilerInterface
 
         $compiler->addDebugInfo($node);
 
-        // Is there are use case for conditional includes at runtime?
-//         if ($node->getAttribute('ignore_missing')) {
-//             $compiler
-//                 ->write("try {\n")
-//                 ->indent()
-//             ;
-//         }
-
         $compiler->isTemplateName = true;
         if ($node->getNode('expr') instanceof Twig_Node_Expression_Constant) {
             $compiler
@@ -66,7 +58,7 @@ class IncludeCompiler implements TypeCompilerInterface
         $compiler->isTemplateName = false;
 
         if (false === $node->getAttribute('only')) {
-            if (!$node->hasNode('variables')) {
+            if (!$this->hasVariablesNode($node)) {
                 $compiler->raw('context');
             } else {
                 $compiler
@@ -84,16 +76,18 @@ class IncludeCompiler implements TypeCompilerInterface
         }
 
         $compiler->raw(");\n");
+    }
 
-//         if ($node->getAttribute('ignore_missing')) {
-//             $compiler
-//                 ->outdent()
-//                 ->write("} catch (Twig_Error_Loader \$e) {\n")
-//                 ->indent()
-//                 ->write("// ignore missing template\n")
-//                 ->outdent()
-//                 ->write("}\n\n")
-//             ;
-//         }
+    private function hasVariablesNode(\Twig_NodeInterface $node)
+    {
+        if (!$node->hasNode('variables')) {
+            return false;
+        }
+
+        if (null === $node->getNode('variables')) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/TwigJs/Compiler/ModuleCompiler.php
+++ b/src/TwigJs/Compiler/ModuleCompiler.php
@@ -57,7 +57,7 @@ abstract class ModuleCompiler
             ->write('return ')
         ;
 
-        if (!$node->hasNode('parent')) {
+        if (!$this->hasParentNode($node)) {
             $compiler->repr(false);
         } else {
             $compiler
@@ -82,7 +82,7 @@ abstract class ModuleCompiler
             ->leaveScope()
         ;
 
-        if ($node->hasNode('parent')) {
+        if ($this->hasParentNode($node)) {
             $compiler
                 ->write("this.getParent(context).render_(sb, context, twig.extend({}, this.getBlocks(), blocks));\n")
             ;
@@ -228,7 +228,7 @@ abstract class ModuleCompiler
         //
         // Put another way, a template can be used as a trait if it
         // only contains blocks and use statements.
-        $traitable = null === $node->hasNode('parent') && 0 === count($node->getNode('macros'));
+        $traitable = null === $this->hasParentNode($node) && 0 === count($node->getNode('macros'));
         if ($traitable) {
             if (!count($nodes = $node->getNode('body'))) {
                 $nodes = new Twig_Node(array($node->getNode('body')));
@@ -276,5 +276,18 @@ abstract class ModuleCompiler
             ->raw(");\n")
         ;
         $compiler->isTemplateName = false;
+    }
+
+    private function hasParentNode(\Twig_NodeInterface $node)
+    {
+        if (!$node->hasNode('parent')) {
+            return false;
+        }
+
+        if (null === $node->getNode('parent')) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Currently when you run `composer --prefer-lowest` the build fails. We should add this check to Travis and resolve what our actual lowest dependencies are.