### PR TITLE
Refactor of Twig expressions tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
     "license": "Apache2",
     "authors": [
         {
+            "name": "Rolf Babijn",
+            "email": "mailrolf@gmail.com"
+        },
+        {
             "name": "Johannes M. Schmitt",
             "email": "schmittjoh@gmail.com",
             "role": "Legacy developer"

--- a/src/TwigJs/Compiler/Expression/Test/ConstantCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/ConstantCompiler.php
@@ -27,7 +27,7 @@ class ConstantCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/DefinedCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/DefinedCompiler.php
@@ -23,13 +23,11 @@ class DefinedCompiler implements TypeCompilerInterface
             );
         }
 
-        $arguments = $node->hasNode('arguments') ? $node->getNode('arguments') : null;
-
         $compiler->subcompile(
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $arguments,
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/DivisiblebyCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/DivisiblebyCompiler.php
@@ -27,7 +27,7 @@ class DivisiblebyCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/EvenCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/EvenCompiler.php
@@ -23,13 +23,11 @@ class EvenCompiler implements TypeCompilerInterface
             );
         }
 
-        $arguments = $node->hasNode('arguments') ? $node->getNode('arguments') : null;
-
         $compiler->subcompile(
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $arguments,
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/NullCompiler.php
@@ -27,7 +27,7 @@ class NullCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/OddCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/OddCompiler.php
@@ -23,13 +23,11 @@ class OddCompiler implements TypeCompilerInterface
             );
         }
 
-        $arguments = $node->hasNode('arguments') ? $node->getNode('arguments') : null;
-
         $compiler->subcompile(
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $arguments,
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );

--- a/src/TwigJs/Compiler/Expression/Test/SameasCompiler.php
+++ b/src/TwigJs/Compiler/Expression/Test/SameasCompiler.php
@@ -27,7 +27,7 @@ class SameasCompiler implements TypeCompilerInterface
             new \Twig_Node_Expression_Test(
                 $node->getNode('node'),
                 $node->getAttribute('name'),
-                $node->getNode('arguments'),
+                $node->hasNode('arguments') ? $node->getNode('arguments') : null,
                 $node->getLine()
             )
         );


### PR DESCRIPTION
These should all have the `getNode` arguments as an option.