### PR TITLE
Added a parent call to the compiler so it is cleared for each new node.

### DIFF
--- a/src/TwigJs/CompileRequestHandler.php
+++ b/src/TwigJs/CompileRequestHandler.php
@@ -50,7 +50,7 @@ class CompileRequestHandler
         try {
             $source = $request->getSource();
             if (is_string($source)) {
-                $source = new \Twig_Source($source, 'inline');
+                $source = new \Twig_Source($source, $request->getName());
             }
             $compiled = $this->env->compileSource($source);
             if ($curCompiler) {

--- a/src/TwigJs/JsCompiler.php
+++ b/src/TwigJs/JsCompiler.php
@@ -319,6 +319,9 @@ class JsCompiler extends \Twig_Compiler
 
     public function compile(\Twig_Node $node, $indentation = 0)
     {
+        // Call parent with an empty node in order to clear the previously compiled template.
+        parent::compile(new \Twig_Node(), $indentation);
+
         $this->subcompile($node);
         return $this;
     }


### PR DESCRIPTION
Also updated the CompileRequestHandler to use the actual file name instead of just "inline" for each template.