### PR TITLE
Add PHP 7.3 to Travis CI settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "4.0-dev"
         }
     }
 }


### PR DESCRIPTION
Since PHP 7.3 is now stable, we should add it to the Travis CI settings to ensure everything will continue to work.